### PR TITLE
Add webpack build for chii_app

### DIFF
--- a/front_end/entrypoints/chii_app/BUILD.gn
+++ b/front_end/entrypoints/chii_app/BUILD.gn
@@ -53,3 +53,27 @@ devtools_entrypoint("entrypoint") {
 
   visibility += devtools_entrypoints_visibility
 }
+
+node_action("webpack_bundle") {
+  script = "node_modules/webpack/bin/webpack.js"
+
+  args = [
+    "--config",
+    rebase_path("//scripts/webpack/chii_app.webpack.config.js", root_build_dir),
+  ]
+
+  inputs = [
+    "chii_app.ts",
+    "global.ts",
+    "main.ts",
+    "../../../scripts/webpack/chii_app.webpack.config.js",
+  ]
+
+  deps = [ ":entrypoint" ]
+
+  outputs = [ "$target_gen_dir/chii_app.webpack.js" ]
+
+  metadata = {
+    grd_files = outputs
+  }
+}

--- a/scripts/webpack/chii_app.webpack.config.js
+++ b/scripts/webpack/chii_app.webpack.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  entry: path.resolve(__dirname, '../../front_end/entrypoints/chii_app/chii_app.ts'),
+  output: {
+    path: path.resolve(__dirname, '../../out/webpack/chii_app'),
+    filename: 'chii_app.js',
+    libraryTarget: 'umd',
+  },
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: 'ts-loader',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add webpack configuration for `chii_app.ts`
- invoke webpack via new `node_action` in `chii_app` build rules
- keep gitignore unchanged

## Testing
- `npm test` *(fails: `vpython3: not found`)*