### PR TITLE
Add webpack build for chii_app

### DIFF
--- a/config/gni/devtools_grd_files.gni
+++ b/config/gni/devtools_grd_files.gni
@@ -297,6 +297,7 @@ grd_files_release_sources = [
   "front_end/emulated_devices/optimized/iPhone6Plus-portrait.avif",
   "front_end/entrypoints/device_mode_emulation_frame/device_mode_emulation_frame.js",
   "front_end/entrypoints/devtools_app/devtools_app.js",
+  "front_end/entrypoints/chii_app/chii_app.generated.js",
   "front_end/entrypoints/chii_app/chii_app.js",
   "front_end/entrypoints/chii_app/main.js",
   "front_end/entrypoints/chii_app/global.js",

--- a/config/gni/devtools_grd_files.gni
+++ b/config/gni/devtools_grd_files.gni
@@ -297,7 +297,6 @@ grd_files_release_sources = [
   "front_end/emulated_devices/optimized/iPhone6Plus-portrait.avif",
   "front_end/entrypoints/device_mode_emulation_frame/device_mode_emulation_frame.js",
   "front_end/entrypoints/devtools_app/devtools_app.js",
-  "front_end/entrypoints/chii_app/chii_app.generated.js",
   "front_end/entrypoints/chii_app/chii_app.js",
   "front_end/entrypoints/chii_app/main.js",
   "front_end/entrypoints/chii_app/global.js",

--- a/front_end/BUILD.gn
+++ b/front_end/BUILD.gn
@@ -17,7 +17,7 @@ group("front_end") {
     "core/i18n/locales",
     "entrypoints/device_mode_emulation_frame",
     "entrypoints/devtools_app:entrypoint",
-    "entrypoints/chii_app:entrypoint",
+    "entrypoints/chii_app:bundle",
     "entrypoints/formatter_worker:worker_entrypoint",
     "entrypoints/heap_snapshot_worker:worker_entrypoint",
     "entrypoints/inspector:entrypoint",

--- a/front_end/entrypoints/chii_app/BUILD.gn
+++ b/front_end/entrypoints/chii_app/BUILD.gn
@@ -9,7 +9,7 @@ devtools_module("chii_app") {
   sources = [ "global.ts", "main.ts" ]
 }
 
-devtools_entrypoint("entrypoint") {
+devtools_entrypoint("bundle") {
   entrypoint = "chii_app.ts"
 
   deps = [
@@ -66,9 +66,12 @@ node_action("bundled_library") {
     "rollup.config.js",
   ]
 
-  deps = [ ":entrypoint" ]
+  deps = [ ":bundle" ]
 
   args = [
+    # TODO(crbug.com/1098074): We need to hide warnings that are written stderr,
+    # as Chromium does not process the returncode of the subprocess correctly
+    # and instead looks if `stderr` is empty.
     "--silent",
     "--config",
     rebase_path("rollup.config.js", root_build_dir),
@@ -78,12 +81,11 @@ node_action("bundled_library") {
     rebase_path(_output_file_location, root_build_dir),
   ]
 
-  if (is_debug) {
-    args += [ "--environment DEBUG_CHII_APP" ]
-  }
 
   outputs = [ _output_file_location ]
   metadata = {
     grd_files = [ _output_file_location ]
   }
 }
+
+

--- a/front_end/entrypoints/chii_app/BUILD.gn
+++ b/front_end/entrypoints/chii_app/BUILD.gn
@@ -46,10 +46,44 @@ devtools_entrypoint("entrypoint") {
   ]
 
   visibility = [
+    ":*",
     "../../:*",
     "../../legacy_test_runner:*",
     "../inspector:*",
   ]
 
   visibility += devtools_entrypoints_visibility
+}
+
+node_action("bundled_library") {
+  script = "node_modules/rollup/dist/bin/rollup"
+
+  _bundled_entrypoint = target_gen_dir + "/chii_app.js"
+  _output_file_location = target_gen_dir + "/chii_app.generated.js"
+
+  inputs = [
+    _bundled_entrypoint,
+    "rollup.config.js",
+  ]
+
+  deps = [ ":entrypoint" ]
+
+  args = [
+    "--silent",
+    "--config",
+    rebase_path("rollup.config.js", root_build_dir),
+    "--input",
+    rebase_path(_bundled_entrypoint, root_build_dir),
+    "--file",
+    rebase_path(_output_file_location, root_build_dir),
+  ]
+
+  if (is_debug) {
+    args += [ "--environment DEBUG_CHII_APP" ]
+  }
+
+  outputs = [ _output_file_location ]
+  metadata = {
+    grd_files = [ _output_file_location ]
+  }
 }

--- a/front_end/entrypoints/chii_app/rollup.config.js
+++ b/front_end/entrypoints/chii_app/rollup.config.js
@@ -1,12 +1,18 @@
-const {terser} = require('../../../node_modules/rollup-plugin-terser/rollup-plugin-terser.js');
+const {
+	terser,
+} = require("../../../node_modules/rollup-plugin-terser/rollup-plugin-terser.js");
 
 function isEnvVarTrue(envVar) {
-  return envVar === 'true';
+	return envVar === "true";
 }
 
-// eslint-disable-next-line import/no-default-export
 export default {
-  treeshake: false,
-  output: [{format: 'iife'}],
-  plugins: !isEnvVarTrue(process.env.DEBUG_CHII_APP) ? [terser()] : []
+	input: "src/index.js",
+	treeshake: false,
+	output: {
+		file: "dist/chii_app.js",
+		format: "cjs",
+		inlineDynamicImports: true,
+	},
+	plugins: !isEnvVarTrue(process.env.DEBUG_INJECTED) ? [terser()] : [],
 };

--- a/front_end/entrypoints/chii_app/rollup.config.js
+++ b/front_end/entrypoints/chii_app/rollup.config.js
@@ -1,0 +1,12 @@
+const {terser} = require('../../../node_modules/rollup-plugin-terser/rollup-plugin-terser.js');
+
+function isEnvVarTrue(envVar) {
+  return envVar === 'true';
+}
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  treeshake: false,
+  output: [{format: 'iife'}],
+  plugins: !isEnvVarTrue(process.env.DEBUG_CHII_APP) ? [terser()] : []
+};


### PR DESCRIPTION
## Summary
- add rollup configuration for `chii_app.ts`
- use a `bundled_library` node action that calls rollup
- list generated bundle in GRD sources

## Testing
- `npm test` *(fails: `vpython3: not found`)*